### PR TITLE
feat(ui): add "restart level" functionality

### DIFF
--- a/src/renderer/components/LoadingMapSceneCenterPanelContents/LoadingMapSceneCenterPanelContents.jsx
+++ b/src/renderer/components/LoadingMapSceneCenterPanelContents/LoadingMapSceneCenterPanelContents.jsx
@@ -21,7 +21,7 @@ import styles from './LoadingMapSceneCenterPanelContents.module.scss'
 import { Button } from '../Button/Button.jsx'
 import { executePromiseWithMinimumDuration } from '../../helpers/executePromiseWithMinimumDuration.js'
 import { prepareStateForGameplay } from '../../store/reducers/prepareStateForGameplay.js'
-import { replaceScene } from '../../store/reducers/replaceScene.js'
+import { pushScene } from '../../store/reducers/pushScene.js'
 import { SCENES } from '../../data/SCENES.js'
 import { setCurrentMap } from '../../store/reducers/setCurrentMap.js'
 import { store } from '../../store/store.js'
@@ -50,7 +50,7 @@ const VARIANTS = {
 // Functions
 /** Fired when the continue button is activated. */
 function handleContinueActivate() {
-	replaceScene(SCENES.PLAY)
+	pushScene(SCENES.PLAY)
 }
 
 

--- a/src/renderer/components/PlaySceneLeftPanelContents/PlaySceneLeftPanelContents.jsx
+++ b/src/renderer/components/PlaySceneLeftPanelContents/PlaySceneLeftPanelContents.jsx
@@ -61,8 +61,7 @@ function handleQuitToDesktopClick() {
 
 /** Fired when the restart level button is clicked. */
 function handleRestartLevelClick() {
-	console.error('Restart Level isn\'t implemented yet.')
-	// pushScene(SCENES.SETTINGS)
+	backToScene(SCENES.LOADING_MAP)
 }
 
 /** Fired when the settings button is clicked. */


### PR DESCRIPTION
Rather than writing new functionality, we're just jumping the player back to the `LoadMap` scene. This scene already clears stale state and prepares the level, so there's little else necessary.