### PR TITLE
fix: use the correct properties to set overworld section width and height

### DIFF
--- a/src/renderer/components/PixiOverworld/PixiOverworld.jsx
+++ b/src/renderer/components/PixiOverworld/PixiOverworld.jsx
@@ -60,8 +60,7 @@ export function PixiOverworld() {
 	} = useMemo(() => ({
 		scaledStageWidth: stageWidth * resolution,
 		scaledStageHeight: stageHeight * resolution,
-	}),
-	[
+	}), [
 		resolution,
 		stageHeight,
 		stageWidth,

--- a/src/renderer/components/PixiOverworldSection/PixiOverworldSection.jsx
+++ b/src/renderer/components/PixiOverworldSection/PixiOverworldSection.jsx
@@ -40,9 +40,9 @@ function mapSectionBlocks(blocks) {
 export function PixiOverworldSection({ data }) {
 	return (
 		<Container
-			height={data.position.height}
+			height={data.size.height}
 			name={data.name}
-			width={data.position.width}
+			width={data.size.width}
 			x={data.position.x}
 			y={data.position.y}>
 			{mapSectionBlocks(data.blocks)}


### PR DESCRIPTION
This doesn't _really_ fix anything, but it eliminates some warnings from the console.