### PR TITLE
fix: fixed console error on map screen

### DIFF
--- a/src/renderer/components/DropdownButton/DropdownButton.jsx
+++ b/src/renderer/components/DropdownButton/DropdownButton.jsx
@@ -82,6 +82,7 @@ export function DropdownButton({
 
 			<Button
 				className={styles['chevron']}
+				hideFromNavGraph
 				isAffirmative={isAffirmative}
 				isNegative={isNegative}
 				isUniformlyPadded


### PR DESCRIPTION
The error was being thrown because we were using `DropbownButton` which rendered a `Button` without the requisite nav graph props. Now the nav graph props are only required if `hideFromNavGraph` is false.